### PR TITLE
Make LD_PRELOAD configurable

### DIFF
--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -185,4 +185,4 @@ if [[ "${LIBLOGFAF_SENDTO}" == '/tmp/'* ]]; then
     fi
 fi
 
-LD_PRELOAD="/lib64/liblogfaf.so" exec "$@"
+LD_PRELOAD="${LD_PRELOAD:-liblogfaf.so}" exec "$@"


### PR DESCRIPTION
Since `LD_PRELOAD="/lib64/liblogfaf.so"` only works on newer docker and `LD_PRELOAD="liblogfaf.so"` only on old versions (like RHEL provided), this needs to be configurable.