### PR TITLE
Docker healthcheck cause some Kubernetes versions to fail to start container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM        centos:7
 
 EXPOSE      25
 VOLUME      /var/spool/mqueue/ /var/spool/clientmqueue
-HEALTHCHECK CMD ["/healthcheck.sh"]
 ENTRYPOINT  ["/entrypoint.sh"]
 CMD         ["/usr/sbin/sendmail", "-bs", "-bD", "-Am"]
 


### PR DESCRIPTION
The "opendaemonsocket: daemon MTA: cannot bind: Address already in use" due to the execution of unwanted docker healthchecks in Kubernetes. I noticed this on 1.5.

```bash

sh-4.2$ /usr/sbin/sendmail -bs -bD -Am -d
Non-set-user-ID binary: RunAsUid = RealUid = 1001
Version 8.14.7
 Compiled with: DNSMAP HESIOD HES_GETMAILHOST LDAPMAP LOG MAP_REGEX
                MATCHGECOS MILTER MIME7TO8 MIME8TO7 NAMED_BIND NETINET NETINET6
                NETUNIX NEWDB NIS PIPELINING SASLv2 SCANF SOCKETMAP STARTTLS
                TCPWRAPPERS USERDB USE_LDAP_INIT
getla(): 0.20
setoption DontBlameSendmail (0xa0)=GroupReadableSASLDBFile,GroupWritableAliasFile,GroupReadableKeyFile,GroupWritableDirPathSafe
setoption ServerSSLOptions (0xe3)=+SSL_OP_NO_SSLv2 +SSL_OP_NO_SSLv3 +SSL_OP_CIPHER_SERVER_PREFERENCE
setoption ClientSSLOptions (0xe4)=+SSL_OP_NO_SSLv2 +SSL_OP_NO_SSLv3
setoption CipherList (0xc0)=HIGH:MEDIUM:!aNULL:!eNULL@STRENGTH
setoption ServerSSLOptions (0xe3)=+SSL_OP_NO_SSLv2 +SSL_OP_NO_SSLv3 +SSL_OP_CIPHER_SERVER_PREFERENCE
setoption ClientSSLOptions (0xe4)=+SSL_OP_NO_SSLv2 +SSL_OP_NO_SSLv3
setoption CipherList (0xc0)=HIGH:MEDIUM:!aNULL:!eNULL@STRENGTH
setoption ServerSSLOptions (0xe3)=+SSL_OP_NO_SSLv2 +SSL_OP_NO_SSLv3 +SSL_OP_CIPHER_SERVER_PREFERENCE
setoption ClientSSLOptions (0xe4)=+SSL_OP_NO_SSLv2 +SSL_OP_NO_SSLv3
setoption CipherList (0xc0)=HIGH:MEDIUM:!aNULL:!eNULL@STRENGTH
setoption SevenBitInput (7)=False
setoption AliasWait (a)=10
setoption AliasFile (A)=/etc/mail/aliases
setoption MinFreeBlocks (b)=100
setoption BlankSub (B)=.
setoption HoldExpensive (c)=False
setoption DeliveryMode (d)=background
setoption TempFileMode (F)=0600
setoption HelpFile (H)=/etc/mail/helpfile
setoption SendMimeErrors (j)=True
setoption ForwardPath (J)= 0x81 z/.forward. 0x81 w: 0x81 z/.forward
setoption ConnectionCacheSize (k)=2
setoption ConnectionCacheTimeout (K)=5m
setoption UseErrorsTo (l)=False
setoption LogLevel (L)=9
setoption CheckAliases (n)=False
setoption OldStyleHeaders (o)=True
setoption DaemonPortOptions (O)=Port=smtp, Name=MTA, M=CE
Daemon MTA flags: <NOCANON,NOETRN>
setoption DaemonPortOptions (O)=Port=smtp, Name=MTA, M=CE
Daemon MTA flags: <NOCANON,NOETRN>
setoption DaemonPortOptions (O)=Port=smtp, Name=MTA, M=CE
Daemon MTA flags: <NOCANON,NOETRN>
setoption DaemonPortOptions (O)=Port=smtp, Name=MTA, M=CE
Daemon MTA flags: <NOCANON,NOETRN>
setoption ClientPortOptions (0xaf)=Family=inet
setoption ClientPortOptions (0xaf)=Family=inet
setoption ClientPortOptions (0xaf)=Family=inet
setoption PrivacyOptions (p)=needmailhelo
setoption MinQueueAge (0x83)=10
setoption QueueDirectory (Q)=/var/spool/mqueue
setoption Timeout (r).connect=1m
setoption Timeout (r).ident=0
setoption Timeout (r).queuereturn=5d
setoption Timeout (r).queuewarn=4h
setoption SuperSafe (s)=True
setoption StatusFile (S)=/dev/null
setoption TimeZoneSpec (t)=
setoption DefaultUser (u)=8:12
setoption UserDatabaseSpec (U)=/etc/mail/userdb.db
setoption TryNullMXList (w)=True
setoption QueueLA (x)=0
setoption RefuseLA (X)=0
setoption SmtpGreetingMessage (0x90)= 0x81 j Sendmail  0x81 v/ 0x81 Z;  0x81 b
setoption UnixFromLine (0x91)=From  0x81 g  0x81 d
setoption OperatorChars (0x92)=.:%@!^/[]+
setoption RunAsUser (0x9d)=openshift:root
setoption DontProbeInterfaces (0xa1)=True
setoption TrustedUser (0xa7)=openshift
setoption PidFile (0x9f)=/tmp/sendmail.pid
setoption AuthMechanisms (0xae)=LOGIN PLAIN CRAM-MD5 DIGEST-MD5 NTLM
setoption AuthOptions (0xbd)=A
setoption CACertPath (0xb9)=/etc/pki/ca-trust/extracted/openssl/
setoption CACertFile (0xb8)=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
getauthinfo: openshift@localhost

============ SYSTEM IDENTITY (after readcf) ============
      (short domain name) $w = 2afec4b12cb4
  (canonical domain name) $j = vm50420.psmanaged.com
         (subdomain name) $m = <null>
              (node name) $k = 2afec4b12cb4
========================================================

assign_queueid: assigned id x6OMYouZ000449, e=0x5560b5854aa0
dropenvelope 0x5560b5854aa0: id=x6OMYouZ000449, flags=4001<OLDSTYLE,METOO>

===== Dropping queue files for x6OMYouZ000449... queueit=0, e_flags=4001<OLDSTYLE,METOO>
getrequests: daemon MTA: port 25
getrequests: daemon MTA: port 25
getrequests: daemon MTA: port 25
getrequests: daemon MTA: port 25
getrequests: daemon MTA: socket 3
getrequests: daemon MTA: socket 4
getrequests: daemon MTA: socket 5
getrequests: daemon MTA: socket 6
getla(): 0.20
getla(): 0.20
451 4.0.0 opendaemonsocket: daemon MTA: cannot listen: Address already in use
syserr: ExitStat = 71
451 4.0.0 opendaemonsocket: daemon MTA: cannot bind: Address already in use
451 4.0.0 opendaemonsocket: daemon MTA: cannot bind: Address already in use
451 4.0.0 opendaemonsocket: daemon MTA: cannot bind: Address already in use
451 4.0.0 opendaemonsocket: daemon MTA: cannot bind: Address already in use
451 4.0.0 opendaemonsocket: daemon MTA: cannot bind: Address already in use
451 4.0.0 opendaemonsocket: daemon MTA: cannot bind: Address already in use
451 4.0.0 opendaemonsocket: daemon MTA: cannot bind: Address already in use
451 4.0.0 opendaemonsocket: daemon MTA: cannot bind: Address already in use
451 4.0.0 opendaemonsocket: daemon MTA: cannot bind: Address already in use
451 4.0.0 opendaemonsocket: daemon MTA: cannot bind: Address already in use
421 4.0.0 opendaemonsocket: daemon MTA: server SMTP socket wedged: exiting
Aborted
sh-4.2$ ps -ax
  PID TTY      STAT   TIME COMMAND
    1 ?        Ss     0:00 /bin/sh
  463 ?        S      0:00 mailq
  464 ?        R+     0:00 ps -ax
sh-4.2$ exit
exit
[root@docker03 ~]# docker run -it --entrypoint="/bin/sh" --name=vm50420.psmanaged.com -e "SENDMAIL_DISABLE_SENDER_RDNS=1" -e "LIBLOGFAF_SENDT
O=/dev/tty" -e "TZ=Europe/Berlin" -e "SENDMAIL_DEFINE_confDOMAIN_NAME=vm50420.psmanaged.com" --no-healthcheck docker.io/jkroepke/openshift-mt
a:latest 
/usr/bin/docker-current: Error response from daemon: Conflict. The name "/vm50420.psmanaged.com" is already in use by container 2afec4b12cb4dc3f6b0f6e043b503f63673b88b02b966079d7e42eca3b2f3d1d. You have to remove (or rename) that container to be able to reuse that name..
See '/usr/bin/docker-current run --help'.
[root@docker03 ~]# docker rm  2a
2a
[root@docker03 ~]# docker run -it --entrypoint="/bin/sh" --name=vm50420.psmanaged.com -e "SENDMAIL_DISABLE_SENDER_RDNS=1" -e "LIBLOGFAF_SENDT
O=/dev/tty" -e "TZ=Europe/Berlin" -e "SENDMAIL_DEFINE_confDOMAIN_NAME=vm50420.psmanaged.com" --no-healthcheck docker.io/jkroepke/openshift-mt
a:latest 
sh-4.2$ /usr/sbin/sendmail -bs -bD -Am -d
Non-set-user-ID binary: RunAsUid = RealUid = 1001
Version 8.14.7
 Compiled with: DNSMAP HESIOD HES_GETMAILHOST LDAPMAP LOG MAP_REGEX
                MATCHGECOS MILTER MIME7TO8 MIME8TO7 NAMED_BIND NETINET NETINET6
                NETUNIX NEWDB NIS PIPELINING SASLv2 SCANF SOCKETMAP STARTTLS
                TCPWRAPPERS USERDB USE_LDAP_INIT
getla(): 0.49
/etc/mail/sendmail.cf: line 87: fileclass: cannot open '/etc/mail/local-host-names': Hard links not allowed
syserr: ExitStat = 71
setoption SevenBitInput (7)=False
setoption AliasWait (a)=10
setoption AliasFile (A)=/etc/aliases
setoption MinFreeBlocks (b)=100
setoption BlankSub (B)=.
setoption HoldExpensive (c)=False
setoption DeliveryMode (d)=background
setoption TempFileMode (F)=0600
setoption HelpFile (H)=/etc/mail/helpfile
setoption SendMimeErrors (j)=True
setoption ForwardPath (J)= 0x81 z/.forward. 0x81 w: 0x81 z/.forward
setoption ConnectionCacheSize (k)=2
setoption ConnectionCacheTimeout (K)=5m
setoption UseErrorsTo (l)=False
setoption LogLevel (L)=9
setoption CheckAliases (n)=False
setoption OldStyleHeaders (o)=True
setoption DaemonPortOptions (O)=Port=smtp,Addr=127.0.0.1, Name=MTA
Daemon MTA flags: 
setoption PrivacyOptions (p)=authwarnings,novrfy,noexpn,restrictqrun
setoption QueueDirectory (Q)=/var/spool/mqueue
setoption Timeout (r).connect=1m
setoption Timeout (r).ident=0
setoption Timeout (r).queuereturn=5d
setoption Timeout (r).queuewarn=4h
setoption SuperSafe (s)=True
setoption StatusFile (S)=/var/log/mail/statistics
setoption DefaultUser (u)=8:12
setoption UserDatabaseSpec (U)=/etc/mail/userdb.db
setoption TryNullMXList (w)=True
setoption SmtpGreetingMessage (0x90)= 0x81 j Sendmail  0x81 v/ 0x81 Z;  0x81 b
setoption UnixFromLine (0x91)=From  0x81 g  0x81 d
setoption OperatorChars (0x92)=.:%@!^/[]+
setoption DontProbeInterfaces (0xa1)=True
setoption AuthOptions (0xbd)=A
/etc/mail/sendmail.cf: line 599: fileclass: cannot open '/etc/mail/trusted-users': Hard links not allowed
getauthinfo: Unknown UID 1001@localhost

============ SYSTEM IDENTITY (after readcf) ============
      (short domain name) $w = 2ffe3ce74170
  (canonical domain name) $j = 2ffe3ce74170
         (subdomain name) $m = <null>
              (node name) $k = 2ffe3ce74170
========================================================

Deny user 1001 attempt to run daemon
Permission denied (real uid not trusted)

====finis: stat 64 e_id=NOQUEUE e_flags=1<OLDSTYLE>
```